### PR TITLE
フォーマットとlintで引っかかったエラーの修正

### DIFF
--- a/pummit/lib/config-manager.go
+++ b/pummit/lib/config-manager.go
@@ -20,6 +20,7 @@ type Gitmoji struct {
 	Schema   string     `json:"$schema"`
 	Gitmojis []Gitmojis `json:"gitmojis"`
 }
+
 type Gitmojis struct {
 	Emoji       string `json:"emoji"`
 	Entity      string `json:"entity"`

--- a/pummit/pummit.go
+++ b/pummit/pummit.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/HidemaruOwO/nuts/log"
 	"github.com/HidemaruOwO/pummit/pummit/cmd"
-	"github.com/HidemaruOwO/pummit/pummit/cmd/alias"
+	alias_cmd "github.com/HidemaruOwO/pummit/pummit/cmd/alias"
 	"github.com/HidemaruOwO/pummit/pummit/config"
 	"github.com/HidemaruOwO/pummit/pummit/lib"
 )
@@ -26,7 +26,7 @@ func main() {
 		}
 	}
 
-	//set flags
+	// set flags
 	version := flag.Bool("version", false, "Print version information")
 	help := flag.Bool("help", false, "Print help")
 	flag.Parse()
@@ -60,7 +60,9 @@ func main() {
 			fmt.Printf("\n")
 			log.Warnf("The alias command requires a second argument\n")
 			os.Exit(0)
-		} else {
+		}
+
+		if len(args) != 1 {
 			if args[1] == "add" {
 				alias_cmd.AliasAddCmd(args)
 			} else if args[1] == "delete" || args[1] == "del" {
@@ -78,6 +80,5 @@ func main() {
 		}
 		os.Exit(0)
 	}
-
 	cmd.RootCmd()
 }


### PR DESCRIPTION
[pummit.go L65](https://github.com/Comamoca/pummit/blob/599898b52bbb3f3602a737845b8d8d9b83eb0361/pummit/pummit.go#L65)はifステートメントの最後に`os.Exit()`があるため、elseステートメントが実行されません。
そのため、elseにする必要がないため該当箇所を分離し、独立したifステートメントになるように変更しました。

また、`go fmt`を実行したので[import文](https://github.com/Comamoca/pummit/blob/599898b52bbb3f3602a737845b8d8d9b83eb0361/pummit/pummit.go#L11)や[Gitmojis構造体付近](https://github.com/Comamoca/pummit/blob/599898b52bbb3f3602a737845b8d8d9b83eb0361/pummit/lib/config-manager.go#L23)が変更されています。