### PR TITLE
補完機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <div align="center">
 
 # pummit 🚛
+
 [![Test CLI](https://github.com/HidemaruOwO/pummit/actions/workflows/build-test.yml/badge.svg)](https://github.com/HidemaruOwO/pummit/actions/workflows/build-test.yml)
 ![最終コミット](https://img.shields.io/github/last-commit/HidemaruOwO/pummit?style=flat-square)
 ![リポジトリのスター](https://img.shields.io/github/stars/HidemaruOwO/pummit?style=flat-square)
@@ -13,7 +14,7 @@
 ## what on Earth is this?
 
 You can easily create a nicely shaped committed message like this one
-  
+
 ![image](https://user-images.githubusercontent.com/82384920/225978215-9ac68cd4-cdb0-44c9-bca3-4d2cff1896cf.png)
 
 </div>
@@ -45,14 +46,18 @@ pummit 'sparkles I am unko man'
 ```
 
 ## Install 😊
+
 If Go is installed, please run this.
+
 ```bash
 go install github.com/HidemaruOwO/pummit/pummit@latest
 ```
 
 https://github.com/HidemaruOwO/pummit/releases
- 
-If Go is not installed, download the appropriate file for your environment from Release and execute the following command.
+
+If Go is not installed, download the appropriate file for your environment from
+Release and execute the following command.
+
 ```bash
 tar xzvf pummit**.tar.gz
 sudo mv pummit /usr/local/bin
@@ -87,7 +92,7 @@ customCommands:
   command: "pummit '{{index .PromptResponses 0}}'"
   context: 'files'
   description: 'commit changes(Custom Command)'
- ```
+```
 
 ### Sample emoji prefixes 🌟
 
@@ -116,12 +121,17 @@ customCommands:
 ```
 
 ## About Alias Function 📎
-For example, typing `wastebasket` is a bit of a challenge, but the alias feature makes it easy to type `wb`.
+
+For example, typing `wastebasket` is a bit of a challenge, but the alias feature
+makes it easy to type `wb`.
+
 ```bash
 $ pummit wb 'Delete module'
 # Result: :wastebasket: Delete module (path/to/added/file)
 ```
+
 The aliases set by default are as follows
+
 ```
  📎 There is aliases
 Alias : Prefix : Emoji
@@ -141,54 +151,83 @@ Alias : Prefix : Emoji
   d : books : 📚
   a : art : 🎨
 ```
+
 ### Add command
+
 This command allows aliases to be added.
+
 ```bash
 $ pummit alias add 's' 'sparkles'
 ```
-In this case, by simply entering the alias `s`, you can assign `sparkles` to the Emoji prefix of the commit message.
+
+In this case, by simply entering the alias `s`, you can assign `sparkles` to the
+Emoji prefix of the commit message.
+
 ```bash
 $ pummit s 'Add new feature'
 # Run: git commit -m ':sparkles: Add new feature (path/to/added/file)'
 ```
+
 ### Delete command
+
 This command allows you to delete an alias.
+
 ```bash
 $ pummit alias delete s
 ```
-In this case, if the `s=spakles` alias is registered and this command is executed, the association between `s` and `sparkles` will be lost. Therefore, if you run the following command, only `s` will be assigned to the Emoji prefix.
+
+In this case, if the `s=spakles` alias is registered and this command is
+executed, the association between `s` and `sparkles` will be lost. Therefore, if
+you run the following command, only `s` will be assigned to the Emoji prefix.
+
 ```bash
 $ pummit s 'Add new feature'
 # Run: git commmit -m ':s: Add new feature (path/to/added/file)'
 ```
+
 You can also specify multiple aliases to delete as arguments.
+
 ```bash
 $ pummit alias delete s sm c h
 ```
 
 ### Delete --all command
+
 This command deletes all registered aliases.
+
 ```bash
 $ pummit alias delete --all
 ```
+
 ### List command
+
 This command displays all registered aliases.
+
 ```bash
 $ pummit alias list
 ```
-f aliases such as `s=sparkles` and `t=tada` are registered, the output will be as follows:
+
+f aliases such as `s=sparkles` and `t=tada` are registered, the output will be
+as follows:
+
 ```bash
 📎 There is aliases
 Alias : Prefix : Emoji
   s : sparkles : ✨ 
-  t : tada : 🎉 
+  t : tada : 🎉
 ```
+
 ### Reset command
+
 This command resets the aliases.
+
 ```bash
 $ pummit alias reset
 ```
-It can be used for recovery when there are too many confusing aliases or when you have directly tampered with `~/.config/pummit/config.json` and caused a bug.
+
+It can be used for recovery when there are too many confusing aliases or when
+you have directly tampered with `~/.config/pummit/config.json` and caused a bug.
+
 ```bash
 $ pummit alias list
  📎 There is aliases
@@ -213,8 +252,10 @@ Alias : Prefix : Emoji
   b : bug : 🐛
   e : eyes : 👀
   d : books : 📚
- ```
-  Even when there are confusingly many aliases like this one
+```
+
+Even when there are confusingly many aliases like this one
+
 ```bash
 $ pummit alias reset
 > May I reset the aliases? :(Y/n) y
@@ -238,8 +279,9 @@ Alias : Prefix : Emoji
   d : books : 📚
   a : art : 🎨
 ```
+
 With a single command, it can be returned to this beautiful state.
 
-
 ## Special Thanks ✨
+
 - [Qiita - GitHubのコミットメッセージに絵文字を入れて開発効率をあげる](https://qiita.com/Jung0/items/0a9a7a97a2c17f92d3c5)

--- a/pummit/autocomplete/bash_autocomplete
+++ b/pummit/autocomplete/bash_autocomplete
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+__pummit_bash_completion()
+{
+    case "$3" in
+        pummit) message="alias";;
+	alias) message=$(compgen -W "add delete list reset" ${COMP_WORDS[COMP_CWORD]});;
+    esac
+    # echo $3
+    COMPREPLY=(${message})
+}
+complete -F __pummit_bash_completion pummit

--- a/pummit/autocomplete/fish_autocomplete.fish
+++ b/pummit/autocomplete/fish_autocomplete.fish
@@ -1,6 +1,5 @@
 #! /bin/env fish
 
-# 2. completeとヘルパ関数で作る作り方
 function __pummit_auto_complete
     printf '%s\t%s\n' 'alias'   ''
 end

--- a/pummit/autocomplete/fish_autocomplete.fish
+++ b/pummit/autocomplete/fish_autocomplete.fish
@@ -1,0 +1,19 @@
+#! /bin/env fish
+
+# 2. completeとヘルパ関数で作る作り方
+function __pummit_auto_complete
+    printf '%s\t%s\n' 'alias'   ''
+end
+
+function __pummit_alias_auto_complete
+    printf '%s\t%s\n' 'add'   ''
+    printf '%s\t%s\n' 'list'   ''
+    printf '%s\t%s\n' 'reset'   ''
+    printf '%s\t%s\n' 'delete'   ''
+end
+
+complete -c pummit -x
+complete -c pummit -x -l help -d 'help'
+
+complete -c pummit -n '__fish_use_subcommand' -xa '(__pummit_auto_complete)'
+complete -c pummit -n '__fish_seen_subcommand_from alias' -xa '(__pummit_alias_auto_complete)'

--- a/pummit/autocomplete/zsh_autocomplete
+++ b/pummit/autocomplete/zsh_autocomplete
@@ -1,0 +1,22 @@
+#compdef pummit
+
+_pummit_zsh_autocomplete() {
+  local -a val
+  subcmd=("alias")
+
+  local -a fruits
+  subcmd2=(add delete list reset)
+
+  _arguments '1: :->arg1' '2: :->arg2'
+
+  case "$state" in
+    arg1)
+      _values $state $subcmd
+      ;;
+    arg2)
+      _values $state $subcmd2
+      ;;
+  esac
+}
+
+compdef _pummit_zsh_autocomplete pummit

--- a/pummit/complete.go
+++ b/pummit/complete.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"embed"
+	"fmt"
+	"log"
+)
+
+//go:embed autocomplete/*
+var static embed.FS
+
+func load(path string) (string, error) {
+	file, err := static.ReadFile(path)
+	if err != nil {
+		log.Fatal("Cant load static file.\n", err)
+		return "", err
+	}
+
+	return string(file), nil
+}
+
+func bashComplete() {
+	script, err := load("autocomplete/bash_autocomplete")
+	if err != nil {
+		log.Fatal("Error: loading bash script is failed.\n", err)
+	}
+	fmt.Println(script)
+}
+
+func zshComplete() {
+	script, err := load("autocomplete/zsh_autocomplete")
+	if err != nil {
+		log.Fatal("Error: loading zsh script is failed.\n", err)
+	}
+	fmt.Println(script)
+}
+
+func fishComplete() {
+	script, err := load("autocomplete/fish_autocomplete.fish")
+	if err != nil {
+		log.Fatal("Error: loading fish script is failed.\n", err)
+	}
+	fmt.Println(script)
+}

--- a/pummit/pummit.go
+++ b/pummit/pummit.go
@@ -73,6 +73,39 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:  "complete",
+			Usage: "Outputs a completion script.",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "bash",
+					Usage: "Outputs a completion script for bash.",
+				},
+				&cli.BoolFlag{
+					Name:  "zsh",
+					Usage: "Outputs a completion script for zsh.",
+				},
+				&cli.BoolFlag{
+					Name:  "fish",
+					Usage: "Outputs a completion script for fish.",
+				},
+			},
+			Action: func(ctx *cli.Context) error {
+				if ctx.Bool("bash") {
+					bashComplete()
+				}
+
+				if ctx.Bool("zsh") {
+					zshComplete()
+				}
+
+				if ctx.Bool("fish") {
+					fishComplete()
+				}
+
+				return nil
+			},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/pummit/pummit.go
+++ b/pummit/pummit.go
@@ -14,8 +14,6 @@ import (
 
 var isDebug bool = config.IsDebug()
 
-var version bool
-
 func main() {
 	envDebug := os.Getenv("DEBUG")
 
@@ -27,7 +25,9 @@ func main() {
 		}
 	}
 
-	app := &cli.App{}
+	app := &cli.App{
+		EnableBashCompletion: true,
+	}
 
 	app.Name = "pummit"
 	app.Usage = "pummit <emoji prefix> <subject>"

--- a/pummit/pummit.go
+++ b/pummit/pummit.go
@@ -32,6 +32,7 @@ func main() {
 	app.Name = "pummit"
 	app.Usage = "pummit <emoji prefix> <subject>"
 	app.Description = "Easily create nicely formatted commit messages "
+
 	app.Version = fmt.Sprintf("%s %s", config.Version, runtime.GOARCH)
 	app.Commands = []*cli.Command{
 		{


### PR DESCRIPTION
`pummit complete`で補完用スクリプトを出力するサブコマンドを追加しました。

このサブコマンドは、フラグに

- bash
- fish
- zsh

の3つのうちどれか1つを指定すると、そのシェルに合う補完用スクリプトを出力します。

実際に使うには
- bash
`eval "$(pummit complete --bash)"`
- fish
`pummit complete --fish | source`
- zsh
`eval "$(pummit complete --zsh)"`

の3つうちどれか1つを実行してください。一般的にはこれらのスニペットを各シェルの設定ファイル(~/.bashrc)などに追記するのがおすすめです。

また、このを実装するため新たに`/autocomplete`ディレクトリを追加しました。
このディレクトリには補完用スクリプトが格納されています。

これらのファイルはgo embedでビルド時にバイナリに埋め込まれるため、スクリプトの修正をする際はプログラム本体を修正する必要はありません。これによりスクリプトの可読性・保守性の向上を図っています。