### PR TITLE
QuickFix: テストビルドが通らない問題を修正

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           mkdir build 
           cd build
-          go build ../pummit/pummit.go
+          go build ../pummit/
           ./pummit
           
 


### PR DESCRIPTION
この問題は、Workflowで実行される`go build ../pummit/pummit.go`コマンドが`complete.go`ファイルを含んでいなことに起因します。
`go run`コマンドや`go build`コマンドでは、対象にファイルを指定すると、**エントリポイントのそのファイルしかコンパイルされません。**つまり`complete.go`はビルド結果に含まれません。**

この問題を修正するために、対象のビルドコマンドを`go build ../pummit/`に変更しました。
この変更でビルド対象にディレクトリを指定することで`complete.go`を含んだビルドを行うことができるようにしています。
