### PR TITLE
引数やオプションが与えられていない時にヘルプを表示する

### DIFF
--- a/pummit/pummit.go
+++ b/pummit/pummit.go
@@ -32,8 +32,7 @@ func main() {
 			if ctx.Args().Present() {
 				cmd.RootCmd(ctx.Args().Get(0), ctx.Args().Get(1))
 			} else {
-				return fmt.Errorf("Error: %s",
-					"Arguments must have both a prefix and an emoji")
+				cli.ShowAppHelp(ctx)
 			}
 
 			return nil


### PR DESCRIPTION
urface/cliの`cli.ShowAppHelp()`はパッケージ内で生成されたヘルプメッセージを表示する関数です。
これを`ctx.Args().Present()`で分岐で引数が確認されない時に実行するよう、デフォルトの挙動を変更しました。

Close #15 