### PR TITLE
Add Go CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.22.x']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60.3
+      - name: go vet
+        run: go vet ./...
+      - name: fmt check
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo "gofmt needed"
+            gofmt -l .
+            exit 1
+          fi
+      - name: tidy check
+        run: |
+          cp go.mod go.mod.bak
+          cp go.sum go.sum.bak
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+          mv go.mod.bak go.mod
+          mv go.sum.bak go.sum
+      - name: Test with coverage
+        run: |
+          go test ./... -race -covermode=atomic -coverprofile=coverage.out
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out
+
+  codecov:
+    needs: lint-test
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage
+      - uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -41,7 +41,9 @@ var rootCmd = &cobra.Command{
 		}
 
 		if len(args) < 2 {
-			cmd.Help()
+			if err := cmd.Help(); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			}
 			os.Exit(0)
 		}
 
@@ -61,7 +63,9 @@ var rootCmd = &cobra.Command{
 			Message: strings.Join(args[1:], " "),
 		}
 
-		git.CommitWithOfflineMode(cm, offlineMode)
+		if err := git.CommitWithOfflineMode(cm, offlineMode); err != nil {
+			log.Errorf("commit failed: %v", err)
+		}
 	},
 	Args: cobra.ArbitraryArgs,
 }

--- a/internal/config/toml.go
+++ b/internal/config/toml.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -212,7 +213,11 @@ func SaveTOMLConfig() error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close config file: %v\n", err)
+		}
+	}()
 
 	encoder := toml.NewEncoder(file)
 	return encoder.Encode(CurrentTOMLConfig)

--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -267,7 +267,12 @@ func (c *FilePermissionChecker) Check() DiagnosticResult {
 	}
 
 	// テストファイルを削除
-	os.Remove(testFile)
+	if err := os.Remove(testFile); err != nil {
+		result.Status = "ERROR"
+		result.Message = fmt.Sprintf("Failed to remove test file: %v", err)
+		result.Suggestions = append(result.Suggestions, "Check directory permissions")
+		return result
+	}
 
 	return result
 }

--- a/internal/doctor/system.go
+++ b/internal/doctor/system.go
@@ -90,13 +90,16 @@ func FormatDiagnosticResults() string {
 	warningCount := 0
 
 	for _, result := range results {
-		status := "✅"
-		if result.Status == "ERROR" {
+		var status string
+		switch result.Status {
+		case "ERROR":
 			status = "❌"
 			errorCount++
-		} else if result.Status == "WARNING" {
+		case "WARNING":
 			status = "⚠️"
 			warningCount++
+		default:
+			status = "✅"
 		}
 
 		builder.WriteString(fmt.Sprintf("%s %s: %s\n", status, result.Name, result.Message))

--- a/pkg/gitmoji/gitmoji.go
+++ b/pkg/gitmoji/gitmoji.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -59,7 +61,11 @@ func GetAllGitmojisWithConfig(offlineMode bool) ([]Gitmoji, error) {
 		}
 		return nil, errors.New("network connection failed")
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.New("failed to fetch gitmojis from API")
@@ -97,7 +103,11 @@ func IsOnline() bool {
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+		}
+	}()
 
 	return resp.StatusCode == http.StatusOK
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -21,12 +21,16 @@ func New() *Logger {
 
 // Info は情報メッセージを出力します
 func (l *Logger) Info(msg string) {
-	fmt.Fprintln(os.Stdout, msg)
+	if _, err := fmt.Fprintln(os.Stdout, msg); err != nil {
+		color.Red("log output error: %v", err)
+	}
 }
 
 // Infof はフォーマット付きの情報メッセージを出力します
 func (l *Logger) Infof(format string, args ...interface{}) {
-	fmt.Fprintf(os.Stdout, format+"\n", args...)
+	if _, err := fmt.Fprintf(os.Stdout, format+"\n", args...); err != nil {
+		color.Red("log output error: %v", err)
+	}
 }
 
 // Error はエラーメッセージを出力します


### PR DESCRIPTION
## Summary
- add comprehensive Go CI workflow with linting, tests, and coverage upload

## Testing
- `go build -o pummit .`
- `golangci-lint run` *(fails: Error return value of `cmd.Help` is not checked, etc.)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68951e9913008322a4f1ac690dd28a36