### PR TITLE
Improve Fetch error handling and add table-driven tests

### DIFF
--- a/pkg/gitmoji/gitmoji.go
+++ b/pkg/gitmoji/gitmoji.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -19,6 +21,50 @@ type Gitmoji struct {
 
 type GitmojiResponse struct {
 	Gitmojis []Gitmoji `json:"gitmojis"`
+}
+
+var (
+	// ErrNonOK indicates the server responded with a non-200 status.
+	ErrNonOK = errors.New("non-200 from server")
+
+	// ErrDecode indicates the response body could not be decoded.
+	ErrDecode = errors.New("failed to decode response")
+)
+
+// Fetch retrieves gitmojis from the given URL using the provided client.
+func Fetch(ctx context.Context, client *http.Client, url string) (
+	GitmojiResponse, error,
+) {
+	if client == nil {
+		client = &http.Client{}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return GitmojiResponse{}, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return GitmojiResponse{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return GitmojiResponse{}, fmt.Errorf(
+			"%w: status=%d", ErrNonOK, resp.StatusCode,
+		)
+	}
+
+	var result GitmojiResponse
+	r := io.LimitReader(resp.Body, 1<<20)
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&result); err != nil {
+		return GitmojiResponse{}, fmt.Errorf("%w: %v", ErrDecode, err)
+	}
+
+	return result, nil
 }
 
 // オフライン対応のGitmoji取得（フォールバック機能付き）
@@ -59,7 +105,7 @@ func GetAllGitmojisWithConfig(offlineMode bool) ([]Gitmoji, error) {
 		}
 		return nil, errors.New("network connection failed")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.New("failed to fetch gitmojis from API")
@@ -97,7 +143,7 @@ func IsOnline() bool {
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return resp.StatusCode == http.StatusOK
 }

--- a/pkg/gitmoji/gitmoji.go
+++ b/pkg/gitmoji/gitmoji.go
@@ -24,6 +24,7 @@ type GitmojiResponse struct {
 }
 
 // maxGitmojiResponseSize prevents memory exhaustion from large payloads.
+// The value is 1MB (1048576 bytes).
 const maxGitmojiResponseSize = 1 << 20
 
 var (

--- a/pkg/gitmoji/gitmoji.go
+++ b/pkg/gitmoji/gitmoji.go
@@ -23,6 +23,9 @@ type GitmojiResponse struct {
 	Gitmojis []Gitmoji `json:"gitmojis"`
 }
 
+// maxGitmojiResponseSize prevents memory exhaustion from large payloads.
+const maxGitmojiResponseSize = 1 << 20
+
 var (
 	// ErrNonOK indicates the server responded with a non-200 status.
 	ErrNonOK = errors.New("non-200 from server")
@@ -57,9 +60,8 @@ func Fetch(ctx context.Context, client *http.Client, url string) (
 	}
 
 	var result GitmojiResponse
-	r := io.LimitReader(resp.Body, 1<<20)
+	r := io.LimitReader(resp.Body, maxGitmojiResponseSize)
 	dec := json.NewDecoder(r)
-	dec.DisallowUnknownFields()
 	if err := dec.Decode(&result); err != nil {
 		return GitmojiResponse{}, fmt.Errorf("%w: %v", ErrDecode, err)
 	}

--- a/pkg/gitmoji/gitmoji_test.go
+++ b/pkg/gitmoji/gitmoji_test.go
@@ -1,0 +1,103 @@
+package gitmoji
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFetch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		ctxFn   func() (context.Context, context.CancelFunc)
+		assert  func(t *testing.T, res GitmojiResponse, err error)
+	}{
+		{
+			name: "success",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(
+					`{"gitmojis":[{"emoji":"🎉","code":":tada:","name":"tada"}]}`,
+				))
+			},
+			ctxFn: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			assert: func(t *testing.T, res GitmojiResponse, err error) {
+				if err != nil {
+					t.Fatalf("Fetch returned error: %v", err)
+				}
+				if len(res.Gitmojis) != 1 || res.Gitmojis[0].Name != "tada" {
+					t.Fatalf("unexpected result: %#v", res)
+				}
+			},
+		},
+		{
+			name: "server error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			ctxFn: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			assert: func(t *testing.T, res GitmojiResponse, err error) {
+				if err == nil || !errors.Is(err, ErrNonOK) {
+					t.Fatalf("expected ErrNonOK, got %v", err)
+				}
+			},
+		},
+		{
+			name: "timeout",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(200 * time.Millisecond)
+				_, _ = w.Write([]byte(`{"gitmojis":[]}`))
+			},
+			ctxFn: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 50*time.Millisecond)
+			},
+			assert: func(t *testing.T, res GitmojiResponse, err error) {
+				if err == nil {
+					t.Fatalf("expected timeout error")
+				}
+				if !errors.Is(err, context.DeadlineExceeded) {
+					t.Fatalf("expected deadline exceeded, got %v", err)
+				}
+			},
+		},
+		{
+			name: "invalid json",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"gitmojis":[`))
+			},
+			ctxFn: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			assert: func(t *testing.T, res GitmojiResponse, err error) {
+				if err == nil || !errors.Is(err, ErrDecode) {
+					t.Fatalf("expected ErrDecode, got %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			ctx, cancel := tc.ctxFn()
+			defer cancel()
+
+			client := &http.Client{}
+			res, err := Fetch(ctx, client, server.URL)
+			tc.assert(t, res, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add context-aware Fetch with sentinel errors and size-limited decoding
- rewrite Fetch unit tests using table-driven cases, including invalid JSON and timeout

## Testing
- `go build -o pummit .`
- `golangci-lint run` *(fails: Error return value of cmd.Help is not checked, etc.)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894e443cce8832285654cf66f662fc9