### PR TITLE
test: add alias command tests

### DIFF
--- a/internal/alias/alias.go
+++ b/internal/alias/alias.go
@@ -25,15 +25,16 @@ var (
 // findAlias searches for an alias by shortcut and returns its index and entry.
 // Returning the actual slice element avoids modifying a copy during updates.
 func findAlias(shortcut string) (int, *config.AliasEntry) {
-  for i := range config.CurrentTOMLConfig.Alias.Entries {
-    entry := &config.CurrentTOMLConfig.Alias.Entries[i]
-    for _, s := range entry.Shortcuts {
-      if s == shortcut {
-        return i, entry
-      }
-    }
-  }
-  return -1, nil
+	// Iterate by index to avoid copying the slice value when taking its address.
+	for i := 0; i < len(config.CurrentTOMLConfig.Alias.Entries); i++ {
+		entry := &config.CurrentTOMLConfig.Alias.Entries[i]
+		for _, s := range entry.Shortcuts {
+			if s == shortcut {
+				return i, entry
+			}
+		}
+	}
+	return -1, nil
 }
 
 // findEmojiIndex searches for an alias by emoji and returns its index.

--- a/internal/alias/alias.go
+++ b/internal/alias/alias.go
@@ -22,8 +22,8 @@ var (
 	ErrAliasNotFound = errors.New("alias not found")
 )
 
-// findAlias searches for an alias by shortcut and returns its index and entry.
-// Returning the actual slice element avoids modifying a copy during updates.
+// findAlias searches for an alias by shortcut and returns its index and a
+// pointer to the entry to enable in-place modifications.
 func findAlias(shortcut string) (int, *config.AliasEntry) {
 	// Iterate by index to avoid copying the slice value when taking its address.
 	for i := 0; i < len(config.CurrentTOMLConfig.Alias.Entries); i++ {

--- a/internal/alias/alias.go
+++ b/internal/alias/alias.go
@@ -22,16 +22,18 @@ var (
 	ErrAliasNotFound = errors.New("alias not found")
 )
 
-// findAlias searches for an alias by shortcut and returns its index and the entry.
+// findAlias searches for an alias by shortcut and returns its index and entry.
+// Returning the actual slice element avoids modifying a copy during updates.
 func findAlias(shortcut string) (int, *config.AliasEntry) {
-	for i, entry := range config.CurrentTOMLConfig.Alias.Entries {
-		for _, s := range entry.Shortcuts {
-			if s == shortcut {
-				return i, &entry
-			}
-		}
-	}
-	return -1, nil
+  for i := range config.CurrentTOMLConfig.Alias.Entries {
+    entry := &config.CurrentTOMLConfig.Alias.Entries[i]
+    for _, s := range entry.Shortcuts {
+      if s == shortcut {
+        return i, entry
+      }
+    }
+  }
+  return -1, nil
 }
 
 // findEmojiIndex searches for an alias by emoji and returns its index.

--- a/internal/cli/alias/add.go
+++ b/internal/cli/alias/add.go
@@ -32,7 +32,7 @@ Otherwise, the emoji will be inferred from the [prefix] argument.`,
 			inferredEmoji, err := emojis.GetEmojiByName(prefix)
 			if err != nil {
 				log.Errorf("Failed to find emoji for prefix '%s': %v. Use --emoji flag to specify it directly.", prefix, err)
-				return nil
+				return err
 			}
 			actualEmoji = inferredEmoji
 			log.Debugf("Inferred emoji: %s", actualEmoji)
@@ -41,10 +41,10 @@ Otherwise, the emoji will be inferred from the [prefix] argument.`,
 		if err := alias.Add(name, prefix, actualEmoji); err != nil {
 			if errors.Is(err, alias.ErrAliasExists) {
 				log.Errorf("Failed to add alias: %v. The alias '%s' might already exist, or the emoji '%s' might be associated with a different prefix.", err, name, actualEmoji)
-				return nil
+				return err
 			}
 			log.Errorf("Failed to add alias: %v", err)
-			return nil
+			return err
 		}
 
 		log.Infof("Added alias '%s' for prefix '%s' with emoji '%s'", name, prefix, actualEmoji)

--- a/internal/cli/alias/alias_test.go
+++ b/internal/cli/alias/alias_test.go
@@ -67,11 +67,6 @@ func captureOutput(t *testing.T, f func() error) (string, error) {
 	if err != nil {
 		t.Fatalf("pipe error: %v", err)
 	}
-	defer func() {
-		if err := w.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
-			t.Fatalf("failed to close writer: %v", err)
-		}
-	}()
 
 	oldStdout, oldStderr := os.Stdout, os.Stderr
 	oldColorOut, oldColorErr := color.Output, color.Error

--- a/internal/cli/alias/alias_test.go
+++ b/internal/cli/alias/alias_test.go
@@ -67,6 +67,11 @@ func captureOutput(t *testing.T, f func() error) (string, error) {
 	if err != nil {
 		t.Fatalf("pipe error: %v", err)
 	}
+	defer func() {
+		if err := w.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("failed to close writer: %v", err)
+		}
+	}()
 
 	oldStdout, oldStderr := os.Stdout, os.Stderr
 	oldColorOut, oldColorErr := color.Output, color.Error

--- a/internal/cli/alias/alias_test.go
+++ b/internal/cli/alias/alias_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 // setupConfig prepares an isolated config for each test to avoid side effects.
-func setupConfig(t *testing.T) {
+func setupConfig(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -30,16 +30,21 @@ func setupConfig(t *testing.T) {
 	color.NoColor = true
 
 	config.CurrentTOMLConfig = config.GetDefaultTOMLConfig()
-	config.TOMLConfigPath = ""
+	configPath := filepath.Join(tmp, "config.toml")
+	if err := os.WriteFile(configPath, []byte{}, 0644); err != nil {
+		t.Fatalf("failed to create temp config file: %v", err)
+	}
+	config.TOMLConfigPath = configPath
 	if err := config.SaveTOMLConfig(); err != nil {
 		t.Fatalf("failed to save temp config: %v", err)
 	}
+	return configPath
 }
 
-// loadConfig reads the current config file for assertions.
-func loadConfig(t *testing.T) config.TOMLConfig {
+// loadConfig reads the config file at the given path for assertions.
+func loadConfig(t *testing.T, configPath string) config.TOMLConfig {
 	t.Helper()
-	data, err := os.ReadFile(config.TOMLConfigPath)
+	data, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("failed to read config: %v", err)
 	}
@@ -97,14 +102,14 @@ func hasShortcut(cfg config.TOMLConfig, sc string) bool {
 }
 
 func TestAliasLifecycle(t *testing.T) {
-	setupConfig(t)
+	configPath := setupConfig(t)
 
 	aliascli.AddCmd.SetArgs([]string{"fs", "sparkles"})
 	if err := aliascli.AddCmd.Execute(); err != nil {
 		t.Fatalf("add command failed: %v", err)
 	}
 
-	cfg := loadConfig(t)
+	cfg := loadConfig(t, configPath)
 	if !hasShortcut(cfg, "fs") {
 		t.Fatalf("alias not added: %+v", cfg.Alias.Entries)
 	}
@@ -125,7 +130,7 @@ func TestAliasLifecycle(t *testing.T) {
 		t.Fatalf("delete command failed: %v", err)
 	}
 
-	cfg = loadConfig(t)
+	cfg = loadConfig(t, configPath)
 	if hasShortcut(cfg, "fs") {
 		t.Fatalf("alias not deleted: %+v", cfg.Alias.Entries)
 	}
@@ -140,7 +145,7 @@ func TestAliasLifecycle(t *testing.T) {
 		t.Fatalf("reset command failed: %v", err)
 	}
 
-	cfg = loadConfig(t)
+	cfg = loadConfig(t, configPath)
 	if hasShortcut(cfg, "fs") {
 		t.Fatalf("alias not reset: %+v", cfg.Alias.Entries)
 	}
@@ -150,7 +155,7 @@ func TestAliasLifecycle(t *testing.T) {
 }
 
 func TestAliasAddDuplicate(t *testing.T) {
-	setupConfig(t)
+	configPath := setupConfig(t)
 
 	aliascli.AddCmd.SetArgs([]string{"fs", "sparkles"})
 	if err := aliascli.AddCmd.Execute(); err != nil {
@@ -168,7 +173,7 @@ func TestAliasAddDuplicate(t *testing.T) {
 		t.Fatalf("expected error output")
 	}
 
-	cfg := loadConfig(t)
+	cfg := loadConfig(t, configPath)
 	count := 0
 	for _, e := range cfg.Alias.Entries {
 		for _, sc := range e.Shortcuts {
@@ -183,7 +188,7 @@ func TestAliasAddDuplicate(t *testing.T) {
 }
 
 func TestAliasDeleteNonExistent(t *testing.T) {
-	setupConfig(t)
+	configPath := setupConfig(t)
 
 	out, err := captureOutput(t, func() error {
 		aliascli.DeleteCmd.SetArgs([]string{"unknown", "--confirm"})
@@ -196,7 +201,7 @@ func TestAliasDeleteNonExistent(t *testing.T) {
 		t.Fatalf("expected error output")
 	}
 
-	cfg := loadConfig(t)
+	cfg := loadConfig(t, configPath)
 	if !reflect.DeepEqual(cfg.Alias, config.GetDefaultTOMLConfig().Alias) {
 		t.Fatalf("config changed after failed delete")
 	}

--- a/internal/cli/alias/alias_test.go
+++ b/internal/cli/alias/alias_test.go
@@ -131,7 +131,9 @@ func TestAliasLifecycle(t *testing.T) {
 	}
 
 	aliascli.AddCmd.SetArgs([]string{"fs", "sparkles"})
-	_ = aliascli.AddCmd.Execute()
+	if err := aliascli.AddCmd.Execute(); err != nil {
+		t.Fatalf("add command (second time) failed: %v", err)
+	}
 
 	aliascli.ResetCmd.SetArgs([]string{"--confirm"})
 	if err := aliascli.ResetCmd.Execute(); err != nil {

--- a/internal/cli/alias/alias_test.go
+++ b/internal/cli/alias/alias_test.go
@@ -27,14 +27,19 @@ func setupConfig(t *testing.T) string {
 	t.Setenv("USERPROFILE", tmp)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
 	t.Setenv("LC_ALL", "C")
+	prevNoColor := color.NoColor
 	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = prevNoColor })
 
+	prevCfg := config.CurrentTOMLConfig
 	config.CurrentTOMLConfig = config.GetDefaultTOMLConfig()
+	t.Cleanup(func() { config.CurrentTOMLConfig = prevCfg })
+
 	configPath := filepath.Join(tmp, "config.toml")
-	if err := os.WriteFile(configPath, []byte{}, 0644); err != nil {
-		t.Fatalf("failed to create temp config file: %v", err)
-	}
+	prevPath := config.TOMLConfigPath
 	config.TOMLConfigPath = configPath
+	t.Cleanup(func() { config.TOMLConfigPath = prevPath })
+
 	if err := config.SaveTOMLConfig(); err != nil {
 		t.Fatalf("failed to save temp config: %v", err)
 	}
@@ -55,7 +60,7 @@ func loadConfig(t *testing.T, configPath string) config.TOMLConfig {
 	return cfg
 }
 
-// captureOutput captures stdout produced by f.
+// captureOutput captures stdout and stderr produced by f.
 func captureOutput(t *testing.T, f func() error) (string, error) {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -63,13 +68,13 @@ func captureOutput(t *testing.T, f func() error) (string, error) {
 		t.Fatalf("pipe error: %v", err)
 	}
 
-	oldStdout := os.Stdout
-	oldColor := color.Output
-	os.Stdout = w
-	color.Output = w
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	oldColorOut, oldColorErr := color.Output, color.Error
+	os.Stdout, os.Stderr = w, w
+	color.Output, color.Error = w, w
 	defer func() {
-		os.Stdout = oldStdout
-		color.Output = oldColor
+		os.Stdout, os.Stderr = oldStdout, oldStderr
+		color.Output, color.Error = oldColorOut, oldColorErr
 	}()
 
 	runErr := f()

--- a/internal/cli/alias/alias_test.go
+++ b/internal/cli/alias/alias_test.go
@@ -1,0 +1,201 @@
+// Tests in this file must not run in parallel because they modify global configuration state.
+
+package alias_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/fatih/color"
+
+	aliaspkg "github.com/HidemaruOwO/pummit/internal/alias"
+	aliascli "github.com/HidemaruOwO/pummit/internal/cli/alias"
+	"github.com/HidemaruOwO/pummit/internal/config"
+)
+
+// setupConfig prepares an isolated config for each test to avoid side effects.
+func setupConfig(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+	t.Setenv("LC_ALL", "C")
+	color.NoColor = true
+
+	config.CurrentTOMLConfig = config.GetDefaultTOMLConfig()
+	config.TOMLConfigPath = ""
+	if err := config.SaveTOMLConfig(); err != nil {
+		t.Fatalf("failed to save temp config: %v", err)
+	}
+}
+
+// loadConfig reads the current config file for assertions.
+func loadConfig(t *testing.T) config.TOMLConfig {
+	t.Helper()
+	data, err := os.ReadFile(config.TOMLConfigPath)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	var cfg config.TOMLConfig
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("failed to unmarshal config: %v", err)
+	}
+	return cfg
+}
+
+// captureOutput captures stdout produced by f.
+func captureOutput(t *testing.T, f func() error) (string, error) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe error: %v", err)
+	}
+
+	oldStdout := os.Stdout
+	oldColor := color.Output
+	os.Stdout = w
+	color.Output = w
+	defer func() {
+		os.Stdout = oldStdout
+		color.Output = oldColor
+	}()
+
+	runErr := f()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close writer: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("failed to read pipe: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("failed to close reader: %v", err)
+	}
+
+	return buf.String(), runErr
+}
+
+// hasShortcut checks whether shortcut exists in cfg.
+func hasShortcut(cfg config.TOMLConfig, sc string) bool {
+	for _, e := range cfg.Alias.Entries {
+		for _, s := range e.Shortcuts {
+			if s == sc {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestAliasLifecycle(t *testing.T) {
+	setupConfig(t)
+
+	aliascli.AddCmd.SetArgs([]string{"fs", "sparkles"})
+	if err := aliascli.AddCmd.Execute(); err != nil {
+		t.Fatalf("add command failed: %v", err)
+	}
+
+	cfg := loadConfig(t)
+	if !hasShortcut(cfg, "fs") {
+		t.Fatalf("alias not added: %+v", cfg.Alias.Entries)
+	}
+
+	out, err := captureOutput(t, func() error {
+		aliascli.ListCmd.SetArgs(nil)
+		return aliascli.ListCmd.Execute()
+	})
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if !strings.Contains(out, "fs") {
+		t.Fatalf("list output missing alias: %s", out)
+	}
+
+	aliascli.DeleteCmd.SetArgs([]string{"fs", "--confirm"})
+	if err := aliascli.DeleteCmd.Execute(); err != nil {
+		t.Fatalf("delete command failed: %v", err)
+	}
+
+	cfg = loadConfig(t)
+	if hasShortcut(cfg, "fs") {
+		t.Fatalf("alias not deleted: %+v", cfg.Alias.Entries)
+	}
+
+	aliascli.AddCmd.SetArgs([]string{"fs", "sparkles"})
+	_ = aliascli.AddCmd.Execute()
+
+	aliascli.ResetCmd.SetArgs([]string{"--confirm"})
+	if err := aliascli.ResetCmd.Execute(); err != nil {
+		t.Fatalf("reset command failed: %v", err)
+	}
+
+	cfg = loadConfig(t)
+	if hasShortcut(cfg, "fs") {
+		t.Fatalf("alias not reset: %+v", cfg.Alias.Entries)
+	}
+	if !reflect.DeepEqual(cfg.Alias, config.GetDefaultTOMLConfig().Alias) {
+		t.Fatalf("aliases not restored to defaults")
+	}
+}
+
+func TestAliasAddDuplicate(t *testing.T) {
+	setupConfig(t)
+
+	aliascli.AddCmd.SetArgs([]string{"fs", "sparkles"})
+	if err := aliascli.AddCmd.Execute(); err != nil {
+		t.Fatalf("initial add failed: %v", err)
+	}
+
+	out, err := captureOutput(t, func() error {
+		aliascli.AddCmd.SetArgs([]string{"fs", "sparkles"})
+		return aliascli.AddCmd.Execute()
+	})
+	if !errors.Is(err, aliaspkg.ErrAliasExists) {
+		t.Fatalf("expected ErrAliasExists, got %v", err)
+	}
+	if out == "" {
+		t.Fatalf("expected error output")
+	}
+
+	cfg := loadConfig(t)
+	count := 0
+	for _, e := range cfg.Alias.Entries {
+		for _, sc := range e.Shortcuts {
+			if sc == "fs" {
+				count++
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("duplicate alias present: %+v", cfg.Alias.Entries)
+	}
+}
+
+func TestAliasDeleteNonExistent(t *testing.T) {
+	setupConfig(t)
+
+	out, err := captureOutput(t, func() error {
+		aliascli.DeleteCmd.SetArgs([]string{"unknown", "--confirm"})
+		return aliascli.DeleteCmd.Execute()
+	})
+	if !errors.Is(err, aliaspkg.ErrAliasNotFound) {
+		t.Fatalf("expected ErrAliasNotFound, got %v", err)
+	}
+	if out == "" {
+		t.Fatalf("expected error output")
+	}
+
+	cfg := loadConfig(t)
+	if !reflect.DeepEqual(cfg.Alias, config.GetDefaultTOMLConfig().Alias) {
+		t.Fatalf("config changed after failed delete")
+	}
+}

--- a/internal/cli/alias/delete.go
+++ b/internal/cli/alias/delete.go
@@ -38,7 +38,7 @@ var DeleteCmd = &cobra.Command{
 		if err := alias.Delete(name); err != nil {
 			if err == alias.ErrAliasNotFound {
 				log.Errorf("The alias '%s' does not exist", name)
-				return nil
+				return err
 			}
 			return err
 		}

--- a/internal/cli/alias/reset.go
+++ b/internal/cli/alias/reset.go
@@ -1,50 +1,50 @@
 package alias
 
 import (
-  "fmt"
+	"fmt"
 
-  "github.com/HidemaruOwO/pummit/internal/alias"
-  "github.com/HidemaruOwO/pummit/internal/prompt"
-  "github.com/HidemaruOwO/pummit/pkg/logger"
-  "github.com/spf13/cobra"
+	"github.com/HidemaruOwO/pummit/internal/alias"
+	"github.com/HidemaruOwO/pummit/internal/prompt"
+	"github.com/HidemaruOwO/pummit/pkg/logger"
+	"github.com/spf13/cobra"
 )
 
 var ResetCmd = &cobra.Command{
-  Use:   "reset",
-  Short: "Reset all alias settings",
-  RunE: func(cmd *cobra.Command, args []string) error {
-    log := logger.New()
+	Use:   "reset",
+	Short: "Reset all alias settings",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log := logger.New()
 
-    confirmFlag, err := cmd.Flags().GetBool("confirm")
-    if err != nil {
-      return fmt.Errorf("failed to get confirm flag: %w", err)
-    }
+		confirmFlag, err := cmd.Flags().GetBool("confirm")
+		if err != nil {
+			return fmt.Errorf("failed to get confirm flag: %w", err)
+		}
 
-    confirmed := confirmFlag
-    if !confirmed {
-      result, err := prompt.Run(
-        "Are you sure you want to reset all alias settings?",
-      )
-      if err != nil {
-        return fmt.Errorf("failed to show confirmation prompt: %w", err)
-      }
-      confirmed = result.Confirmed
-    }
+		confirmed := confirmFlag
+		if !confirmed {
+			result, err := prompt.Run(
+				"Are you sure you want to reset all alias settings?",
+			)
+			if err != nil {
+				return fmt.Errorf("failed to show confirmation prompt: %w", err)
+			}
+			confirmed = result.Confirmed
+		}
 
-    if !confirmed {
-      log.Info("Reset canceled")
-      return nil
-    }
+		if !confirmed {
+			log.Info("Reset canceled")
+			return nil
+		}
 
-    if err := alias.Reset(); err != nil {
-      return err
-    }
+		if err := alias.Reset(); err != nil {
+			return err
+		}
 
-    log.Info("All alias settings have been reset")
-    return nil
-  },
+		log.Info("All alias settings have been reset")
+		return nil
+	},
 }
 
 func init() {
-  ResetCmd.Flags().Bool("confirm", false, "Skip confirmation prompt")
+	ResetCmd.Flags().Bool("confirm", false, "Skip confirmation prompt")
 }

--- a/internal/cli/alias/reset.go
+++ b/internal/cli/alias/reset.go
@@ -1,36 +1,50 @@
 package alias
 
 import (
-	"fmt"
+  "fmt"
 
-	"github.com/HidemaruOwO/pummit/internal/alias"
-	"github.com/HidemaruOwO/pummit/internal/prompt"
-	"github.com/HidemaruOwO/pummit/pkg/logger"
-	"github.com/spf13/cobra"
+  "github.com/HidemaruOwO/pummit/internal/alias"
+  "github.com/HidemaruOwO/pummit/internal/prompt"
+  "github.com/HidemaruOwO/pummit/pkg/logger"
+  "github.com/spf13/cobra"
 )
 
 var ResetCmd = &cobra.Command{
-	Use:   "reset",
-	Short: "Reset all alias settings",
-	// Short: "すべてのエイリアス設定をリセットします",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		log := logger.New()
+  Use:   "reset",
+  Short: "Reset all alias settings",
+  RunE: func(cmd *cobra.Command, args []string) error {
+    log := logger.New()
 
-		result, err := prompt.Run("Are you sure you want to reset all alias settings?")
-		if err != nil {
-			return fmt.Errorf("failed to show confirmation prompt: %w", err)
-		}
+    confirmFlag, err := cmd.Flags().GetBool("confirm")
+    if err != nil {
+      return fmt.Errorf("failed to get confirm flag: %w", err)
+    }
 
-		if !result.Confirmed {
-			log.Info("Reset canceled")
-			return nil
-		}
+    confirmed := confirmFlag
+    if !confirmed {
+      result, err := prompt.Run(
+        "Are you sure you want to reset all alias settings?",
+      )
+      if err != nil {
+        return fmt.Errorf("failed to show confirmation prompt: %w", err)
+      }
+      confirmed = result.Confirmed
+    }
 
-		if err := alias.Reset(); err != nil {
-			return err
-		}
+    if !confirmed {
+      log.Info("Reset canceled")
+      return nil
+    }
 
-		log.Info("All alias settings have been reset")
-		return nil
-	},
+    if err := alias.Reset(); err != nil {
+      return err
+    }
+
+    log.Info("All alias settings have been reset")
+    return nil
+  },
+}
+
+func init() {
+  ResetCmd.Flags().Bool("confirm", false, "Skip confirmation prompt")
 }

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -83,4 +83,4 @@ func Run(question string) (Result, error) {
 	}
 
 	return Result{Confirmed: finalModel.Confirmed}, nil
-} 
+}


### PR DESCRIPTION
## Summary
- test alias add/list/delete/reset lifecycle with isolated config
- propagate errors from add and delete commands
- refine captureOutput cleanup to close pipes explicitly

## Testing
- `go build -o pummit .`
- `golangci-lint run` (fails: cmd.Help, git.CommitWithOfflineMode, file.Close, os.Remove, resp.Body.Close, fmt.Fprintln, fmt.Fprintf, staticcheck tagged switch)
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894e4278fc88322b2aa95dafadf2648